### PR TITLE
Fix image path on testbed page

### DIFF
--- a/testbed.md
+++ b/testbed.md
@@ -49,7 +49,7 @@ Text with extra blank lines above and below
 
 Plain image:
 
-![plain image](/images/photo.jpg)
+![plain image]({{ '/images/photo.jpg' | relative_url }})
 
 # Heading 1
 


### PR DESCRIPTION
## Summary
- use `relative_url` filter on plain image in `testbed.md`

## Testing
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688c3e198bf8832c905940cd683f1894